### PR TITLE
Bring latest tests to master to the CI environment will use them.

### DIFF
--- a/tests/api/test_live.py
+++ b/tests/api/test_live.py
@@ -356,6 +356,15 @@ class TestGetResourceList(unittest.TestCase):
         self.assertIsNotNone(newres)
         self.resources_to_delete.append(newres)
 
+        # Test resource type in system metadata
+        sysmeta = hs.getSystemMetadata(newres)
+        self.assertEqual(sysmeta['resource_type'], rtype)
+
+        # Test resource type in resource list
+        for resource in hs.getResourceList():
+            if resource['resource_id'] == newres:
+                self.assertEqual(resource['resource_type'], rtype)
+
     def test_oauth2_authentication(self):
         if self.client_id is None or self.client_secret is None:
             self.skipTest("OAuth2 client ID/secret not specified.")

--- a/tests/api/test_live.py
+++ b/tests/api/test_live.py
@@ -357,6 +357,9 @@ class TestGetResourceList(unittest.TestCase):
         self.resources_to_delete.append(newres)
 
     def test_oauth2_authentication(self):
+        if self.client_id is None or self.client_secret is None:
+            self.skipTest("OAuth2 client ID/secret not specified.")
+
         hs = self.get_hs_oauth2()
 
         # Create a public resource
@@ -383,6 +386,9 @@ class TestGetResourceList(unittest.TestCase):
         self.assertGreater(private_count,public_count, "Private("+str(private_count)+") not greater than public("+str(public_count)+") ")
 
     def test_oauth2_authentication_token(self):
+        if self.client_id is None or self.client_secret is None:
+            self.skipTest("OAuth2 client ID/secret not specified.")
+
         hs = self.get_hs_oauth2_token()
 
         # Create a public resource

--- a/tests/api/test_live.py
+++ b/tests/api/test_live.py
@@ -8,7 +8,7 @@ import unittest
 from datetime import date, datetime
 import requests
 
-from hs_restclient import HydroShare, HydroShareAuthBasic
+from hs_restclient import HydroShare, HydroShareAuthBasic, HydroShareAuthOAuth2
 from hs_restclient import  HydroShareNotFound,HydroShareNotAuthorized, HydroShareException,HydroShareHTTPException
 
 
@@ -19,20 +19,35 @@ class TestGetResourceList(unittest.TestCase):
     def setUp(self):
         self.resources_to_delete = []
         self.url = os.environ['HYDROSHARE'] if os.environ.get('HYDROSHARE') is not None else "dev.hydroshare.org"
-        self.use_https = os.getenv('USE_HTTPS', 'False')
+        self.use_https = os.getenv('USE_HTTPS', 'True')
         if self.use_https == 'True':
             self.use_https = True
         else:
             self.use_https = False
 
+        self.verify = os.getenv('VERIFY_CERTS', 'True')
+        if self.verify == 'True':
+            self.verify = True
+        else:
+            self.verify = False
+
         self.port = os.environ.get('PORT', None)
+
+        # OAuth2
+        self.client_id = os.environ.get('CLIENT_ID', None)
+        self.client_secret = os.environ.get('CLIENT_SECRET', None)
 
         # need to have some generic titles. Not sure how we can pass them
         self.creator = os.environ['Creator'] if os.environ.get('Creator') is not None else 'admin'
         self.creatorPassword = os.environ.get('CreatorPassword') # if it's empty, fail the auth tests
         self.auth = None
+        self.oauth = None
         if self.creatorPassword:
             self.auth = HydroShareAuthBasic(username=self.creator,password=self.creatorPassword)
+            if self.client_id and self.client_secret:
+                self.oauth = HydroShareAuthOAuth2(self.client_id, self.client_secret,
+                                                  self.url, use_https=self.use_https, port=self.port,
+                                                  username=self.creator, password=self.creatorPassword)
         # items to look up. Present info from dev.hydroshare.org
         self.a_Title = os.environ['ResourceTitle'] if  os.environ.get('ResourceTitle') is not None else 'Logan DEM'
         self.a_resource_id = os.environ['ResourceId'] if os.environ.get('ResourceId') is not None else 'e327f29ff92b4871a4a94556db7b7635'
@@ -162,7 +177,8 @@ class TestGetResourceList(unittest.TestCase):
         self.assertIsNotNone(self.auth, "Auth not provided")
         hs = None
         try:
-            hs = HydroShare(hostname=self.url, auth=self.auth, use_https=self.use_https, port=self.port)
+            hs = HydroShare(hostname=self.url, auth=self.auth, use_https=self.use_https, verify=self.verify,
+                            port=self.port)
         except:
             self.fail("Authorized Connection Failed" + sys.exc_info()[0])
         return hs
@@ -170,9 +186,19 @@ class TestGetResourceList(unittest.TestCase):
     def get_hs_noauth(self):
         hs = None
         try:
-            hs = HydroShare(hostname=self.url, use_https=self.use_https, port=self.port)
+            hs = HydroShare(hostname=self.url, use_https=self.use_https, verify=self.verify,
+                            port=self.port)
         except:
             self.fail("Anonymous Connection Failed" + sys.exc_info()[0])
+        return hs
+
+    def get_hs_oauth2(self):
+        hs = None
+        try:
+            hs = HydroShare(hostname=self.url, auth=self.oauth, use_https=self.use_https, verify=self.verify,
+                            port=self.port)
+        except:
+            self.fail("OAuth2 Connection Failed" + str(sys.exc_info()[0]))
         return hs
 
     def test_get_public_resource_noauth(self):
@@ -297,6 +323,33 @@ class TestGetResourceList(unittest.TestCase):
         newres = hs.createResource(rtype, title, resource_filename=fname, keywords=keywords, abstract=abstract)
         self.assertIsNotNone(newres)
         self.resources_to_delete.append(newres)
+
+    def test_oauth2_authentication(self):
+        hs = self.get_hs_oauth2()
+
+        # Create a public resource
+        self._create_resource_without_file(hs, abstract='This is a public resource',
+                                           title='My public resource', keywords=('this is public', 'a resource'),
+                                           is_public=True)
+
+        # Create two private resources
+        self._create_resource_without_file(hs, abstract='This is private resource 1',
+                                           title='My public resource, no. 1', keywords=('this is private', 'resource1'))
+        self._create_resource_without_file(hs, abstract='This is private resource 2',
+                                           title='My public resource, no. 2', keywords=('this is private', 'resource2'))
+
+        # Count public and private resources
+        public_count = 0
+        private_count = 0
+        res_list = hs.getResourceList(creator=self.creator)
+        for res in res_list:
+            if res['public'] is True:
+                public_count += 1
+            else:
+                private_count += 1
+
+        self.assertGreater(private_count,public_count, "Private("+str(private_count)+") not greater than public("+str(public_count)+") ")
+
 
 #     @with_httmock(mocks.hydroshare.resourceFileCRUD)
 #     def test_create_get_delete_resource_file(self):


### PR DESCRIPTION
Adds tests for:
- OAuth
- Ensuring resource types returned by /hsapi/resourceList correspond to actual resource types (see https://github.com/hydroshare/hydroshare/issues/752)
